### PR TITLE
Fix array index error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ As soon as the used strings is nearly fixed, you can help us on our project page
 The application icon is based upon the [Android Robot][3] logo made by Google Inc. This logo is licensed under the terms of the [Creative Commons Attribution license][4]. The battery icon was designed by the authors of the [GNOME High contrast icon set][5] and is licensed under the terms of the [GNU Lesser General Public License][6].
 
 ## Changelog
+### Version 2.1.1 (Code: *211*, Released on: ***2017-06-16***) - [Changes][39]
+* Fix an ArrayOutOfBounds error
+
 ### Version 2.1 (Code: *210*, Released on: ***2017-06-16***) - [Changes][38]
 * Fix the back arrow in the settings categories to go back to the correct page
 * Fix the axes of the battery graph to always show 0% - 100%
@@ -264,3 +267,4 @@ The application icon is based upon the [Android Robot][3] logo made by Google In
  [36]: https://github.com/thuetz/Energize/compare/v1.0...v2.0
  [37]: https://github.com/thuetz/Energize/compare/v2.0...v2.0.1
  [38]: https://github.com/thuetz/Energize/compare/v2.0.1...v2.1
+ [39]: https://github.com/thuetz/Energize/compare/v2.1...v2.1.1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
 		applicationId "com.halcyonwaves.apps.energize"
 		minSdkVersion 14
 		targetSdkVersion 25
-		versionCode 210
-		versionName '2.1'
+		versionCode 211
+		versionName '2.1.1'
 		testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 		vectorDrawables.useSupportLibrary = true
 		versionNameSuffix ''

--- a/app/src/main/assets/xml/changelog.xml
+++ b/app/src/main/assets/xml/changelog.xml
@@ -2,6 +2,12 @@
 <changelog>
 	<release
 		releasedate="2017-06-16"
+		version="2.1.1"
+		versioncode="211">
+		<change>Fix an ArrayOutOfBounds error</change>
+	</release>
+	<release
+		releasedate="2017-06-16"
 		version="2.1"
 		versioncode="210">
 		<change>Fix the back arrow in the settings categories to go back to the correct page</change>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,6 @@
 	<string-array name="pref_list_batteryestimationmethod_names">
 		<item>Last change period (inaccurate)</item>
 		<item>Last n-change periods (bit inaccurate)</item>
-		<item>Heuristic estimation</item>
 	</string-array>
 
 	<!-- CATEGORY: The actual values for preferences where the user has the choice between different settings -->


### PR DESCRIPTION
There was an old estimator in the preference which was not used anymore and caused an ArrayOutOfBounds exception when selecting it in the preferences. This pull request removes the old estimation method.